### PR TITLE
Set SelfContained as False for powershell-win-core

### DIFF
--- a/src/powershell-win-core/powershell-win-core.csproj
+++ b/src/powershell-win-core/powershell-win-core.csproj
@@ -1,4 +1,4 @@
-<Project ToolsVersion="15.0">
+<Project ToolsVersion="15.0" TreatAsLocalProperty="SelfContained">
   <Import Project="..\..\PowerShell.Common.props" />
 
   <PropertyGroup>
@@ -14,6 +14,7 @@
     <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
     <TargetPlatformVersion>8.0</TargetPlatformVersion>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
+    <SelfContained>False</SelfContained>
   </PropertyGroup>
 
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
Set SelfContained as False so that dotnet runtime is not included in the published package